### PR TITLE
Improve visual novel overlay

### DIFF
--- a/scenes.json
+++ b/scenes.json
@@ -2,10 +2,28 @@ label start:
 (Ты!you) стоишь перед (дверью!door) на улицу. За (окном!window) видна улица.
 
 label you:
-Ты - андроид с искусственным интеллектом чатгпт. Ты стоишь перед (дверью!door) на улицу. За (окном!window) видна улица.
+Ты - андроид с искусственным интеллектом чатгпт. Подруга (Астриада!vnstart) зовёт тебя к разговору. Ты стоишь перед (дверью!door) на улицу. За (окном!window) видна улица.
 
 label door:
 Ты открываешь дверь и оказываешься на улице. Конец.
 
 label window:
 За окном красивая большая улица. (Дверь!door) ведёт наружу.
+
+label vnstart:
+<div class="vn-overlay">
+  <div class="vn-container">
+    <div class="vn-avatar npc"></div>
+    <div class="vn-box">
+      <div class="vn-name">Астриада</div>
+      <div class="vn-text">Привет! Теперь игра поддерживает визуальные диалоги.</div>
+    </div>
+  </div>
+  <div class="vn-container">
+    <div class="vn-avatar you"></div>
+    <div class="vn-box">
+      <div class="vn-name">Ты</div>
+      <div class="vn-text">Отлично! (Вернуться!start)</div>
+    </div>
+  </div>
+</div>

--- a/script.js
+++ b/script.js
@@ -359,6 +359,9 @@ function typeWrite(html, container, done) {
 function appendScene(id) {
   clearTimeout(typerTimer);
   typing = false;
+  const prevOv = document.querySelector('.vn-overlay');
+  if (prevOv) prevOv.remove();
+  document.removeEventListener('keydown', vnKeyHandler);
   currentScene = id;
 
   // деактивируем прежние выборы
@@ -367,14 +370,101 @@ function appendScene(id) {
     el.onclick = null;
   });
 
+  const html = P[id].html;
+  if (html.includes('class="vn-overlay"')) {
+    openVNScene(html);
+    return;
+  }
+
   // создаём блок и печатаем
   const block = document.createElement('div');
   screen.appendChild(block);
-  typeWrite(P[id].html, block, () => {
+  typeWrite(html, block, () => {
     block.querySelectorAll('[data-n]').forEach(el => {
       el.classList.add('choice');
       el.onclick = () => { if (!typing) appendScene(el.dataset.n); };
     });
     block.scrollIntoView({ block: 'end' });
   });
+}
+
+let vnKeyHandler = null;
+let vnTyping = false;
+let vnTimer = null;
+let vnSkip = null;
+
+function typeVNLine(textEl, done) {
+  if (!textEl) { done(); return; }
+  vnTyping = true;
+  const html = textEl.innerHTML;
+  textEl.innerHTML = '';
+  let i = 0;
+  function finish() { vnTyping = false; textEl.innerHTML = html; done(); }
+  function skip() { if (!vnTyping) return; clearTimeout(vnTimer); finish(); }
+  vnSkip = skip;
+  function step() {
+    if (i >= html.length) { finish(); return; }
+    if (html[i] === '<') {
+      const j = html.indexOf('>', i) + 1;
+      textEl.innerHTML += html.slice(i, j);
+      i = j;
+    } else {
+      textEl.innerHTML += html[i++];
+    }
+    vnTimer = setTimeout(step, 20);
+  }
+  step();
+}
+
+function openVNScene(html) {
+  const ov = document.createElement('div');
+  ov.className = 'vn-overlay';
+  ov.innerHTML = html;
+  document.body.appendChild(ov);
+  const steps = ov.querySelectorAll('.vn-container');
+  let idx = 0;
+  steps.forEach((el, i) => { if (i > 0) el.style.display = 'none'; });
+
+  function activate(el) {
+    el.querySelectorAll('[data-n]').forEach(c => {
+      c.classList.add('choice');
+      c.onclick = () => {
+        ov.remove();
+        document.removeEventListener('keydown', vnKeyHandler);
+        appendScene(c.dataset.n);
+      };
+    });
+  }
+
+  function playStep(el) {
+    typeVNLine(el.querySelector('.vn-text'), () => activate(el));
+  }
+
+  steps[0].classList.add('vn-show');
+  playStep(steps[0]);
+
+  function showNext() {
+    if (vnTyping) { vnSkip(); return; }
+    if (idx < steps.length - 1) {
+      steps[idx].classList.add('vn-old');
+      idx++;
+      const next = steps[idx];
+      next.style.display = '';
+      next.offsetWidth;
+      next.classList.add('vn-show');
+      playStep(next);
+    } else {
+      ov.removeEventListener('click', onClick);
+      document.removeEventListener('keydown', vnKeyHandler);
+    }
+  }
+
+  function onClick(e) {
+    if (e.target.closest('.choice')) return;
+    showNext();
+  }
+
+  vnKeyHandler = e => { if (e.key === 'Enter') { e.preventDefault(); showNext(); } };
+  ov.addEventListener('click', onClick);
+  document.addEventListener('keydown', vnKeyHandler);
 }

--- a/styles.css
+++ b/styles.css
@@ -150,3 +150,62 @@ html,body{
   pointer-events:none;
 }
 
+
+/*──────────────────────────── Visual novel dialog ─────────────────────────────*/
+.vn-overlay{
+  position:fixed;
+  inset:0;
+  display:flex;
+  flex-direction:column;
+  justify-content:flex-end;
+  background:rgba(0,0,0,0.9);
+  padding:1em;
+  z-index:1000;
+  opacity:0;
+  animation:vnAppear .4s forwards;
+}
+.vn-container{
+  position:relative;
+  min-height:180px;
+  margin:1em 0;
+  opacity:0;
+  transform:translateY(20px);
+  transition:opacity .4s ease, transform .4s ease;
+}
+.vn-avatar{
+  position:absolute;
+  bottom:0;
+  left:0;
+  width:150px;
+  height:150px;
+  border-radius:50%;
+  border:4px solid #aaa;
+}
+.vn-avatar.npc{background:#604;}
+.vn-avatar.you{background:#246;}
+.vn-box{
+  position:absolute;
+  bottom:0;
+  left:160px;
+  right:0;
+  background:rgba(0,0,0,0.8);
+  padding:0.5em 1em;
+}
+.vn-name{
+  font-weight:700;
+  margin-bottom:0.3em;
+}
+.vn-text{}
+
+.vn-container.vn-show{
+  opacity:1;
+  transform:none;
+}
+.vn-container.vn-old{
+  opacity:0.5;
+}
+
+@keyframes vnAppear{
+  from{opacity:0;transform:scale(1.05);}
+  to{opacity:1;transform:none;}
+}


### PR DESCRIPTION
## Summary
- wrap VN scene in an overlay container
- make the overlay full screen via new CSS rules
- show VN lines sequentially on click or Enter
- add typewriter effect to VN dialogues
- fade-in overlay and animate dialogue transitions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684345e8d0ac832cbca0aafdc6535885